### PR TITLE
c-c-c-changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,14 @@
 FROM tiangolo/uwsgi-nginx-flask:python2.7
+LABEL maintainer="it-cpe@gusto.com"
+LABEL description="Reposado/Margarita instance for use by Gusto's IT CPE team"
 
-COPY margarita /app
-COPY requirements.txt /app/
-COPY saml /app/
+COPY saml margarita requirements.txt /app/
 
-RUN ln -s /reposado/code/reposadolib /app/
-RUN ln -s /reposado/code/preferences.plist /app/
+RUN apt-get update -y && apt-get -y install libxmlsec1-dev
 
-RUN apt-get update -y && apt-get upgrade -y && apt-get -y install libxmlsec1-dev
+RUN ln -s /reposado/code/reposadolib /app/ && ln -s /reposado/code/preferences.plist /app/
+
 RUN pip install --no-cache-dir -r requirements.txt
 
 HEALTHCHECK --interval=5s --timeout=2s --retries=12 \
   CMD curl --silent --fail localhost:9200/_cluster/health || exit 1
-
-EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ Quick Start
 ------------
 
 1. Clone this repository, enter directory
-2. `docker build . -t margarita`
-3. Edit the docker-compose.yml file (*required for SAML auth*):
+2. Edit the docker-compose.yml file (*required for SAML auth*):
 
   a. `/path/to/your/saml/:/app/saml` Path to SAML certs and configuration. See [SAML Configuration](#SAML Configuration).
 
@@ -22,8 +21,8 @@ Quick Start
 
   If you have preexisting volumes or host paths with this data, and would prefer not to rebuild, enter those paths here. Otherwise, leave commented.
 
-4. `SAML_AUTH_ENABLED=True docker-compose up -d`
-5. Debugging your SAML auth? `DEBUG=True SAML_AUTH_ENABLED=True docker-compose up`
+3. `SAML_AUTH_ENABLED=True docker-compose up -d`
+4. Debugging your SAML auth? `DEBUG=True SAML_AUTH_ENABLED=True docker-compose up`
 
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - reposado:/reposado
 
   margarita:
-    image: "margarita"
+    build: .
     ports:
      - "80:80"
     volumes:
@@ -21,4 +21,4 @@ services:
       - reposado
 
 volumes:
-  reposado:
+  reposado: {}


### PR DESCRIPTION
**Changes Requested:**
1. Condense `COPY` statements to a single Docker layer (line)
2. Condense `ln` statements to a single Docker layer (line)
3. Remove `apt-get upgrade -y` (as per Docker's "Best Practices" => https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get)
4. Add `LABEL`'s 
5. Remove `EXPOSE 80` as it is unnecessary and any host-container port-mapping inherently exposes the defined port.
6. Modify `margarita` service in `docker-compose.yml` to reflect build-at-run-time for Margarita container (thereby negating the need to `docker build -t w0de/margasado:latest` before running `docker-compose up -d`).
7. Modify `README.md` to reflect above changes